### PR TITLE
feat: subsctiption management in app

### DIFF
--- a/app/(authenticated)/(tabs)/discover/[activityId].tsx
+++ b/app/(authenticated)/(tabs)/discover/[activityId].tsx
@@ -187,7 +187,6 @@ export const ActivityDetailInformation = ({
         >
           <CoreInfoBox
             Icon={CurrencyEur}
-            activity={activity}
             label="Price"
             value={
               activity.estimatedCost ? `€${activity.estimatedCost}` : "Free"
@@ -201,13 +200,11 @@ export const ActivityDetailInformation = ({
                 size={20}
               />
             )}
-            activity={activity}
             label="Required energy"
             value={activity.energyRequired}
           />
           <CoreInfoBox
             Icon={BabyCarriage}
-            activity={activity}
             label="Min age"
             value={`${activity.minAge ? activity.minAge + " +" : "Any"}`}
           />
@@ -225,7 +222,6 @@ export const ActivityDetailInformation = ({
               <View>
                 <CoreInfoBox
                   Icon={MapPinLine}
-                  activity={activity}
                   label="Location"
                   value={`${
                     activity.locationName ? activity.locationName : "N/A"
@@ -602,19 +598,12 @@ function PlanningSheetView({
 }
 
 interface infoBoxProps {
-  activity: ActivityDetails;
-  Icon: Icon;
+  Icon?: Icon;
   label: string;
   value: string;
   children?: any;
 }
-const CoreInfoBox = ({
-  activity,
-  Icon,
-  label,
-  value,
-  children,
-}: infoBoxProps) => {
+export const CoreInfoBox = ({ Icon, label, value, children }: infoBoxProps) => {
   return (
     <View
       style={{
@@ -625,13 +614,15 @@ const CoreInfoBox = ({
         flex: 1,
       }}
     >
-      <Icon
-        size={20}
-        style={{
-          marginTop: 8,
-        }}
-        color={TextColors.muted.color}
-      />
+      {Icon ? (
+        <Icon
+          size={20}
+          style={{
+            marginTop: 8,
+          }}
+          color={TextColors.muted.color}
+        />
+      ) : null}
       <View
         style={{
           flexDirection: "column",

--- a/app/(authenticated)/(tabs)/profile/settings/_layout.tsx
+++ b/app/(authenticated)/(tabs)/profile/settings/_layout.tsx
@@ -33,6 +33,12 @@ export default function PorfileStackLayout() {
             title: "Account",
           }}
         />
+        <Stack.Screen
+          name="subscription"
+          options={{
+            title: "Subscription",
+          }}
+        />
       </Stack>
     </>
   );

--- a/app/(authenticated)/(tabs)/profile/settings/index.tsx
+++ b/app/(authenticated)/(tabs)/profile/settings/index.tsx
@@ -4,6 +4,7 @@ import {
   BellRinging,
   CaretRight,
   Code,
+  Crown,
   Gear,
   Icon,
   IconProps,
@@ -57,6 +58,15 @@ export default function SettingsScreen() {
             icon={User}
             onPress={() =>
               router.push("/(authenticated)/(tabs)/profile/settings/account")
+            }
+          />
+          <SettingsTile
+            title="Subscription"
+            icon={Crown}
+            onPress={() =>
+              router.push(
+                "/(authenticated)/(tabs)/profile/settings/subscription"
+              )
             }
           />
           <SettingsTile title="Notifications" icon={BellRinging} />

--- a/app/(authenticated)/(tabs)/profile/settings/subscription.tsx
+++ b/app/(authenticated)/(tabs)/profile/settings/subscription.tsx
@@ -1,0 +1,325 @@
+import { lightStyles, ViButton } from "@/components/ViButton";
+import { ViDivider } from "@/components/ViDivider";
+import { ViInput } from "@/components/ViInput";
+import {
+  safeAreaEdges,
+  safeAreaStyles,
+  TextColors,
+  textStyles,
+} from "@/globalStyles";
+import {
+  useChangePlan,
+  useGetActiveSubscription,
+  useGetAvalablePlans,
+} from "@/hooks/useSubscription";
+import { router } from "expo-router";
+import { Check, Crown, Icon, Lightning } from "phosphor-react-native";
+
+import {
+  View,
+  Text,
+  StyleSheet,
+  Image,
+  ScrollView,
+  StyleProp,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { CoreInfoBox } from "../../discover/[activityId]";
+import { useQueryClient } from "@tanstack/react-query";
+
+export default function SubscriptionScreen({
+  embedded = false,
+}: {
+  embedded?: boolean;
+}) {
+  var dateOptions = {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  } as Intl.DateTimeFormatOptions;
+
+  const {
+    isLoading: loadingPlans,
+    data: plans,
+    error: planError,
+  } = useGetAvalablePlans();
+  const {
+    isLoading: loadingSubscription,
+    data: subscription,
+    error: subscriptionError,
+    refetch: refreshCurrentSubscription,
+  } = useGetActiveSubscription();
+
+  const { mutate, isPending, error } = useChangePlan();
+  const queryClient = useQueryClient();
+  async function handleChangePlan(planId: number) {
+    mutate(
+      {
+        planId: planId,
+      },
+      {
+        onSuccess: (data) => {
+          queryClient.invalidateQueries({
+            queryKey: ["suggested-activity-list"],
+          });
+          queryClient
+            .invalidateQueries({ queryKey: ["get-active-subscription"] })
+            .then(() => refreshCurrentSubscription());
+        },
+      }
+    );
+  }
+
+  return (
+    <SafeAreaView style={[!embedded && safeAreaStyles]} edges={safeAreaEdges}>
+      <View
+        style={{
+          height: "100%",
+          display: "flex",
+        }}
+      >
+        <ScrollView style={[styles.Container]}>
+          <View
+            style={{
+              flexDirection: "column",
+              gap: 8,
+            }}
+          >
+            {subscription ? (
+              <View id="currentPlan" style={styles.Card}>
+                <View
+                  style={{
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                  }}
+                >
+                  <Text style={textStyles.h4}>Current plan</Text>
+                  <Text>Active</Text>
+                </View>
+                <MonthlyPriceContainer
+                  Icon={Lightning}
+                  name={subscription.name}
+                  price={subscription.price}
+                />
+                <ViDivider
+                  style={{
+                    marginBlock: 8,
+                    opacity: 0.5,
+                  }}
+                />
+                <View
+                  style={{
+                    flexDirection: "row",
+                  }}
+                >
+                  <CoreInfoBox
+                    label="AI Requests/day"
+                    value={subscription?.maxAIRequestsPerDay?.toString() ?? ""}
+                  />
+                  <CoreInfoBox
+                    label="AI Results shown"
+                    value={subscription?.maxAIResultsShown?.toString() ?? ""}
+                  />
+                </View>
+                {subscription.slug != "free" ? (
+                  <View
+                    style={{
+                      flexDirection: "row",
+                    }}
+                  >
+                    <CoreInfoBox
+                      label="Next billing"
+                      value={
+                        subscription.endDate
+                          ? new Date(subscription.endDate).toLocaleDateString(
+                              "nl-be",
+                              dateOptions
+                            )
+                          : "N/A"
+                      }
+                    />
+                    <CoreInfoBox
+                      label="Auto renew"
+                      value={subscription?.autoRenew ? "On" : "Off"}
+                    />
+                  </View>
+                ) : null}
+                <ViButton
+                  title="Cancel subscription"
+                  variant="danger"
+                  enabled={subscription.slug != "free"}
+                  onPress={() => {
+                    const freeID = plans?.find(
+                      (plan) => plan.slug == "free"
+                    )?.planId;
+                    freeID ? handleChangePlan(freeID) : null;
+                  }}
+                />
+              </View>
+            ) : null}
+
+            {plans ? (
+              <View
+                style={{
+                  gap: 8,
+                }}
+              >
+                <Text
+                  style={[
+                    textStyles.h3,
+                    {
+                      paddingTop: 8,
+                    },
+                  ]}
+                >
+                  Avalable plans
+                </Text>
+
+                {plans.map((plan) => {
+                  return (
+                    <View key={plan.planId} style={styles.Card}>
+                      <View
+                        style={{
+                          flexDirection: "row",
+                          gap: 8,
+
+                          alignItems: "center",
+                          justifyContent: "space-between",
+                        }}
+                      >
+                        <View
+                          style={{
+                            flexDirection: "row",
+                            gap: 8,
+                            alignItems: "center",
+                          }}
+                        >
+                          {plan.slug == "free" ? <Lightning /> : <Crown />}
+                          <Text style={textStyles.h4}>{plan.name}</Text>
+                        </View>
+                        <Text>
+                          {subscription?.slug == plan.slug ? "Current" : ""}
+                        </Text>
+                      </View>
+                      <MonthlyPriceContainer price={plan.price} />
+                      <View
+                        style={{
+                          paddingBlock: 8,
+                          gap: 4,
+                        }}
+                      >
+                        <View
+                          style={{
+                            flexDirection: "row",
+                            gap: 4,
+                            alignItems: "center",
+                          }}
+                        >
+                          <Check
+                            size={18}
+                            color={lightStyles.primary.backgroundColor}
+                            weight="bold"
+                          />
+                          <Text>
+                            {plan.maxAIRequestsPerDay} AI Requests per day
+                          </Text>
+                        </View>
+                        <View
+                          style={{
+                            flexDirection: "row",
+                            gap: 4,
+                            alignItems: "center",
+                          }}
+                        >
+                          <Check
+                            size={18}
+                            color={lightStyles.primary.backgroundColor}
+                            weight="bold"
+                          />
+                          <Text>{plan.maxAIResultsShown} Results shown</Text>
+                        </View>
+                      </View>
+                      <ViButton
+                        title={
+                          subscription?.slug == plan.slug
+                            ? "Current plan"
+                            : "Switch plan"
+                        }
+                        enabled={subscription?.slug != plan.slug}
+                        onPress={() => {
+                          handleChangePlan(plan.planId);
+                        }}
+                      />
+                    </View>
+                  );
+                })}
+              </View>
+            ) : null}
+          </View>
+        </ScrollView>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+interface MonthlyPriceContainerProps {
+  name?: string;
+  Icon?: Icon;
+  price: number;
+}
+function MonthlyPriceContainer({
+  name,
+  Icon,
+  price,
+}: MonthlyPriceContainerProps) {
+  return (
+    <View
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 8,
+        transform: [
+          {
+            translateY: 2,
+          },
+        ],
+      }}
+    >
+      {Icon ? <Icon /> : null}
+      <View>
+        {name ? <Text style={{ fontWeight: 600 }}>{name} plan</Text> : null}
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "flex-end",
+            transform: [
+              {
+                translateY: -2,
+              },
+            ],
+          }}
+        >
+          <Text style={[textStyles.h4]}>€{price}</Text>
+          <Text style={TextColors.muted}>/month</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  Container: {
+    paddingInline: 16,
+    flexDirection: "column",
+    gap: 8,
+  },
+  Card: {
+    backgroundColor: "#fff",
+    borderRadius: 16,
+    padding: 16,
+    boxShadow: "0px 4px 12px rgba(0, 0, 0, 0.1)",
+    flexDirection: "column",
+    gap: 8,
+  },
+});

--- a/components/ViPremiumModalSheet.tsx
+++ b/components/ViPremiumModalSheet.tsx
@@ -1,3 +1,4 @@
+import SubscriptionScreen from "@/app/(authenticated)/(tabs)/profile/settings/subscription";
 import { BackgroundColors, textStyles } from "@/globalStyles";
 import {
   BottomSheetBackdrop,
@@ -6,6 +7,7 @@ import {
 } from "@gorhom/bottom-sheet";
 import { useRef } from "react";
 import { Text, View } from "react-native";
+import { ScrollView } from "react-native-reanimated/lib/typescript/Animated";
 
 interface ViPremiumModalSheetProps {
   BottomSheetModalRef: React.RefObject<BottomSheetModal>;
@@ -34,7 +36,7 @@ export const ViPremiumModalSheet = ({
           boxShadow: "-10px -10px 10px rgba(0,0,0,0.1)",
         },
       ]}
-      enableContentPanningGesture={false} // Prevents modal drag from content
+      //enableContentPanningGesture={false} // Prevents modal drag from content
     >
       <BottomSheetView>
         <View
@@ -45,7 +47,24 @@ export const ViPremiumModalSheet = ({
             justifyContent: "center",
           }}
         >
-          <Text style={textStyles.h3}>Upgrade to Vi-Premium!</Text>
+          <Text
+            style={[
+              textStyles.h3,
+              {
+                paddingBlock: 16,
+              },
+            ]}
+          >
+            Upgrade to Vi-Premium!
+          </Text>
+
+          <View
+            style={{
+              width: "100%",
+            }}
+          >
+            <SubscriptionScreen embedded={true} />
+          </View>
         </View>
       </BottomSheetView>
     </BottomSheetModal>

--- a/hooks/useSubscription.ts
+++ b/hooks/useSubscription.ts
@@ -1,0 +1,58 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useApiClient } from "./apiClient";
+import { Plan, Subscription } from "@/types/subscription";
+
+export const useGetActiveSubscription = ({
+  enabled = true,
+}: {
+  enabled?: boolean;
+} = {}) => {
+  const api = useApiClient();
+  return useQuery<Subscription>({
+    queryKey: ["get-active-subscription"], //! UNIQUE !
+    queryFn: async () => {
+      const result = await api<{
+        data: Subscription;
+      }>(`/subscription`);
+      return result.data;
+    },
+    staleTime: 0, // 1000 * 60 * 60 * 24, // 1 day
+    enabled: enabled,
+  });
+};
+export const useGetAvalablePlans = ({
+  enabled = true,
+}: {
+  enabled?: boolean;
+} = {}) => {
+  const api = useApiClient();
+  return useQuery<Plan[]>({
+    queryKey: ["get-available-plans"], //! UNIQUE !
+    queryFn: async () => {
+      const result = await api<{
+        data: Plan[];
+      }>(`/subscription/plans`);
+      return result.data;
+    },
+    staleTime: 1000 * 60 * 60, // 1 hour
+    enabled: enabled,
+  });
+};
+
+export const useChangePlan = () => {
+  const api = useApiClient();
+  return useMutation({
+    mutationFn: async ({ planId }: { planId: number | string }) => {
+      const result = await api<{
+        data: Subscription;
+      }>(`/subscription`, {
+        method: "POST",
+        body: JSON.stringify({
+          planId: planId,
+        }),
+      });
+
+      return result.data;
+    },
+  });
+};

--- a/hooks/useSuggestedActivities.ts
+++ b/hooks/useSuggestedActivities.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useApiClient } from "./apiClient";
-import { ActivitySuggestion, AISuggestionResponse } from "@/types/activity";
+import { AISuggestionResponse } from "@/types/activity";
 
 export const useGetSuggestedActivities = ({
   enabled = true,
@@ -19,6 +19,12 @@ export const useGetSuggestedActivities = ({
         data: AISuggestionResponse;
       }>(`/activitySuggestions?lon=${lon?.toString()}&lat=${lat?.toString()}`);
       return result.data;
+    },
+    retry: (failureCount, error) => {
+      if (error?.status === 404) {
+        return false; // ❌ No retry on not found error
+      }
+      return failureCount < 3; // Retry other errors up to 3 times
     },
     staleTime: 1000 * 60 * 5, // 5 minutes
     enabled: enabled,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@shopify/react-native-skia": "1.5.0",
         "@tanstack/react-query": "^5.80.6",
         "expo": "~52.0.46",
-        "expo-blur": "~14.0.3",
         "expo-clipboard": "~7.0.1",
         "expo-constants": "~17.0.8",
         "expo-device": "~7.0.3",
@@ -7292,17 +7291,6 @@
         "invariant": "^2.2.4",
         "md5-file": "^3.2.3"
       },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo-blur": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-14.0.3.tgz",
-      "integrity": "sha512-BL3xnqBJbYm3Hg9t/HjNjdeY7N/q8eK5tsLYxswWG1yElISWZmMvrXYekl7XaVCPfyFyz8vQeaxd7q74ZY3Wrw==",
-      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@shopify/react-native-skia": "1.5.0",
     "@tanstack/react-query": "^5.80.6",
     "expo": "~52.0.46",
-    "expo-blur": "~14.0.3",
     "expo-clipboard": "~7.0.1",
     "expo-constants": "~17.0.8",
     "expo-device": "~7.0.3",

--- a/types/subscription.ts
+++ b/types/subscription.ts
@@ -1,0 +1,26 @@
+export type Subscription = {
+  subscriptionId: number;
+  userId: number;
+  planId: number;
+  startDate: string | null;
+  endDate: string | null;
+  isActive: boolean;
+  autoRenew: boolean;
+  name: string;
+  slug: string;
+  price: number;
+  currency: string;
+  maxAIRequestsPerDay: number;
+  maxAIResultsShown: number;
+};
+
+export type Plan = {
+  planId: number;
+  name: string;
+  slug: string;
+  price: number;
+  currency: string;
+  maxAIRequestsPerDay: number;
+  maxAIResultsShown: number;
+  isActive: boolean;
+};


### PR DESCRIPTION
- Make coreInfoBox reusable
- Handle if user has no AI suggestions yet just generate some for them to avoid confusion
- Add Subscription management screen
- Add Functionality to switch subscriptions and invalidate queries related to subscriptions
- Added subscription popup in drawer when clicking premium locked feature
- Added endpoints to manage subscriptions
- Made getActivitySuggestions not retry if 404 -> just requests AI suggestion generation instead
- Remove no longer used Expo blur package (causes graphical glitches on android)
- Types related to subscriptions